### PR TITLE
fixed seconds vs minutes bug

### DIFF
--- a/Sources/HTTPResponse.swift
+++ b/Sources/HTTPResponse.swift
@@ -326,11 +326,11 @@ public extension HTTPResponse {
 			case .absoluteDate(let date):
 				cookieLine.append(";expires=" + date)
 			case .absoluteSeconds(let seconds):
-				let formattedDate = (seconds*60).secondsToDate()
+				let formattedDate = seconds.secondsToDate()
 					.formatDate(format: "%a, %d-%b-%Y %T GMT")  ?? "INVALID DATE"
 				cookieLine.append(";expires=" + formattedDate)
 			case .relativeSeconds(let seconds):
-				let formattedDate = (Double.now + (seconds*60).secondsToDate())
+				let formattedDate = (Double.now + seconds.secondsToDate())
 					.formatDate(format: "%a, %d-%b-%Y %T GMT") ?? "INVALID DATE"
 				cookieLine.append(";expires=" + formattedDate)
 			}


### PR DESCRIPTION
the ENUM described . relativeSeconds(Int) and absoluteSeconds(Int) but then in the case statement, both were being multiplied by 60, turning them into minutes. I removed the multiplication.

An alternative option is to change the ENUM to .relativeMinutes. But thats a bit odd and not very compatible with integers because chances are, developers will want second level precision.

We should consider changing this to Double because thats how NSTimeInterval represents seconds.
