### PR TITLE
Enable the usage of files with white spaces.

### DIFF
--- a/Sources/StaticFileHandler.swift
+++ b/Sources/StaticFileHandler.swift
@@ -79,7 +79,7 @@ public struct StaticFileHandler {
 			// !FIX! need 404.html or some such thing
 			response.completed()
 		}
-        var path = request.path
+        var path = request.path.removingPercentEncoding
 		if path[path.index(before: path.endIndex)] == "/" {
 			path.append("index.html") // !FIX! needs to be configurable
 		}

--- a/Sources/StaticFileHandler.swift
+++ b/Sources/StaticFileHandler.swift
@@ -79,7 +79,7 @@ public struct StaticFileHandler {
 			// !FIX! need 404.html or some such thing
 			response.completed()
 		}
-        var path = request.path.removingPercentEncoding
+        var path = request.path.removingPercentEncoding ?? request.path
 		if path[path.index(before: path.endIndex)] == "/" {
 			path.append("index.html") // !FIX! needs to be configurable
 		}


### PR DESCRIPTION
When the url is encoded, the perfect file handler is unable fine the file because of percentageEncoding.
Removing this encoding to the file path fixes the issue.