### PR TITLE
Remove warnings if on Swift 4.2 or higher

### DIFF
--- a/Sources/PerfectHTTP/HTTPHeaders.swift
+++ b/Sources/PerfectHTTP/HTTPHeaders.swift
@@ -33,9 +33,15 @@ public enum HTTPRequestHeader {
 		case xB3TraceId, xB3SpanId, xB3ParentSpanId
 		case custom(name: String)
 		
+        #if swift(>=4.2)
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(standardName.lowercased())
+        }
+        #else
 		public var hashValue: Int {
 			return standardName.lowercased().hashValue
 		}
+        #endif
 		
 		public var standardName: String {
 			switch self {
@@ -228,9 +234,15 @@ public enum HTTPResponseHeader {
 		case xB3ParentSpanId
 		case custom(name: String)
 		
-		public var hashValue: Int {
-			return standardName.lowercased().hashValue
-		}
+        #if swift(>=4.2)
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(standardName.lowercased())
+        }
+        #else
+        public var hashValue: Int {
+            return standardName.lowercased().hashValue
+        }
+        #endif
 		
 		public var standardName: String {
 			switch self {

--- a/Sources/PerfectHTTP/HTTPHeaders.swift
+++ b/Sources/PerfectHTTP/HTTPHeaders.swift
@@ -33,15 +33,15 @@ public enum HTTPRequestHeader {
 		case xB3TraceId, xB3SpanId, xB3ParentSpanId
 		case custom(name: String)
 		
-        #if swift(>=4.2)
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(standardName.lowercased())
-        }
-        #else
-		public var hashValue: Int {
-			return standardName.lowercased().hashValue
-		}
-        #endif
+		#if swift(>=4.2)
+			public func hash(into hasher: inout Hasher) {
+				hasher.combine(standardName.lowercased())
+			}
+		#else
+			public var hashValue: Int {
+				return standardName.lowercased().hashValue
+			}
+		#endif
 		
 		public var standardName: String {
 			switch self {
@@ -234,15 +234,15 @@ public enum HTTPResponseHeader {
 		case xB3ParentSpanId
 		case custom(name: String)
 		
-        #if swift(>=4.2)
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(standardName.lowercased())
-        }
-        #else
-        public var hashValue: Int {
-            return standardName.lowercased().hashValue
-        }
-        #endif
+		#if swift(>=4.2)
+			public func hash(into hasher: inout Hasher) {
+				hasher.combine(standardName.lowercased())
+			}
+		#else
+			public var hashValue: Int {
+				return standardName.lowercased().hashValue
+			}
+		#endif
 		
 		public var standardName: String {
 			switch self {

--- a/Sources/PerfectHTTP/HTTPMethod.swift
+++ b/Sources/PerfectHTTP/HTTPMethod.swift
@@ -59,15 +59,15 @@ public enum HTTPMethod: Hashable, CustomStringConvertible {
 		}
 	}
     
-    #if swift(>=4.2)
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(description)
-    }
-    #else
-    public var hashValue: Int {
-        return description.hashValue
-    }
-    #endif
+	#if swift(>=4.2)
+		public func hash(into hasher: inout Hasher) {
+			hasher.combine(description)
+		}
+	#else
+		public var hashValue: Int {
+			return description.hashValue
+	}
+	#endif
 	
 	/// The method as a String
 	public var description: String {

--- a/Sources/PerfectHTTP/HTTPMethod.swift
+++ b/Sources/PerfectHTTP/HTTPMethod.swift
@@ -58,10 +58,16 @@ public enum HTTPMethod: Hashable, CustomStringConvertible {
 		default:        return .custom(string)
 		}
 	}
-	
-	public var hashValue: Int {
-		return description.hashValue
-	}
+    
+    #if swift(>=4.2)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(description)
+    }
+    #else
+    public var hashValue: Int {
+        return description.hashValue
+    }
+    #endif
 	
 	/// The method as a String
 	public var description: String {

--- a/Sources/PerfectHTTP/TypedRoutes.swift
+++ b/Sources/PerfectHTTP/TypedRoutes.swift
@@ -99,14 +99,14 @@ public extension HTTPRequest {
 			// fudging url vars and json post body is inefficient
 			let data: Data
 			if !urlVariables.isEmpty,
-				var dict = try JSONSerialization.jsonObject(with: Data(bytes: body), options: []) as? [String:Any] {
+				var dict = try JSONSerialization.jsonObject(with: Data(body), options: []) as? [String:Any] {
 				urlVariables.forEach {
 					let (key, value) = $0
 					dict[key] = value
 				}
 				data = try JSONSerialization.data(withJSONObject: dict, options: [])
 			} else {
-				data = Data(bytes: body)
+				data = Data(body)
 			}
 			do {
 				return try JSONDecoder().decode(A.self, from: data)


### PR DESCRIPTION
- Use hash(into:) if running on Swift Version 4.2 or higher
- Change Data(bytes: body) to Data(body)